### PR TITLE
Fix failure to build on Cordova Android 7+ caused by manifest path

### DIFF
--- a/hooks/lib/android/manifestWriter.js
+++ b/hooks/lib/android/manifestWriter.js
@@ -18,7 +18,7 @@ module.exports = {
  * @param {Object} pluginPreferences - plugin preferences as JSON object; already parsed
  */
 function writePreferences(cordovaContext, pluginPreferences) {
-  var pathToManifest = path.join(cordovaContext.opts.projectRoot, 'platforms', 'android', 'AndroidManifest.xml');
+  var pathToManifest = path.join(cordovaContext.opts.projectRoot, 'platforms', 'android', 'app', 'src', 'main', 'AndroidManifest.xml');
   var manifestSource = xmlHelper.readXmlAsJson(pathToManifest);
   var cleanManifest;
   var updatedManifest;


### PR DESCRIPTION
- [ ] Fix compatibility with older Cordova versions by adding a version check and applying the older path in the case of an old version.