### PR TITLE
Fix app crashing when the url opened has no host

### DIFF
--- a/src/android/com/nordnetab/cordova/ul/UniversalLinksPlugin.java
+++ b/src/android/com/nordnetab/cordova/ul/UniversalLinksPlugin.java
@@ -205,7 +205,13 @@ public class UniversalLinksPlugin extends CordovaPlugin {
      */
     private ULHost findHostByUrl(Uri url) {
         ULHost host = null;
-        final String launchHost = url.getHost().toLowerCase();
+
+        String launchHost = url.getHost();
+        if (launchHost == null) {
+            launchHost = "";
+        }
+        launchHost = launchHost.toLowerCase();
+
         for (ULHost supportedHost : supportedHosts) {
             if (supportedHost.getName().equals(launchHost) ||
                     supportedHost.getName().startsWith("*.") && launchHost.endsWith(supportedHost.getName().substring(1))) {


### PR DESCRIPTION
This might be the case when, in addition to universal links, you use custom scheme URLs, that often do not include a host.